### PR TITLE
Add and configure fancybox for creating image galleries.

### DIFF
--- a/src/main/kotlin/com/physman/templates/General.kt
+++ b/src/main/kotlin/com/physman/templates/General.kt
@@ -18,13 +18,38 @@ fun FlowContent.nonImageAttachmentTemplate(nonImageAttachments: List<AttachmentV
     }
 }
 
-fun FlowContent.imageAttachmentTemplate(images: List<AttachmentView>) {
+fun FlowContent.galleryTemplate(galleryId: String, images: List<AttachmentView>) {
     if (images.isNotEmpty()) {
         section {
             classes = setOf("gallery")
             images.forEach { attachmentView: AttachmentView ->
-                img(src = attachmentView.thumbnailUrl, alt = attachmentView.attachment.originalFilename)
+                a(href = attachmentView.url) {
+                    attributes["data-fancybox"] = galleryId
+                    img(src = attachmentView.thumbnailUrl, alt = attachmentView.attachment.originalFilename)
+                }
             }
+        }
+    }
+}
+
+fun FlowContent.fancyboxSetupScript() {
+    script {
+        unsafe {
+            +"""
+                Fancybox.bind("[data-fancybox]", {
+                    Toolbar: {
+                        display: {
+                        left: ["infobar"],
+                        middle: [
+                        "zoomIn",
+                        "zoomOut",
+                        "rotateCCW",
+                      ],
+                      right: ["close"],
+                    },
+                  },
+                });
+            """.trimIndent()
         }
     }
 }

--- a/src/main/kotlin/com/physman/templates/Layouts.kt
+++ b/src/main/kotlin/com/physman/templates/Layouts.kt
@@ -5,12 +5,20 @@ import kotlinx.html.*
 fun HEAD.headTags() {
     // htmx
     script { src = "https://unpkg.com/htmx.org@2.0.4" }
+
     // _hyperscript
     script { src = "https://unpkg.com/hyperscript.org@0.9.13" }
+
     // picoCSS defaults
     link(rel = "stylesheet", href = "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
+
     // material icons
     link(rel = "stylesheet", href = "https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded")
+
+    // fancybox
+    script { src = "https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.umd.js" }
+    link(rel = "stylesheet", href = "https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.css")
+
     // custom CSS TODO: for prod, change this to a GCP file
     link(rel = "stylesheet", href = "https://storage.googleapis.com/studyshare-static/styles.css")
 //    link(rel = "stylesheet", href = "/static/styles.css")
@@ -128,5 +136,6 @@ fun HTML.index(
         main(classes = "container") {
             block()
         }
+        fancyboxSetupScript()
     }
 }

--- a/src/main/kotlin/com/physman/templates/Solution.kt
+++ b/src/main/kotlin/com/physman/templates/Solution.kt
@@ -36,9 +36,8 @@ fun FlowContent.solutionTemplate(solutionView: SolutionView) {
                 }
             }
 
-            imageAttachmentTemplate(images)
+            galleryTemplate("gallery-${solutionView.solution.id}", images)
             nonImageAttachmentTemplate(nonImageAttachments)
-            // TODO: Hiding comments, button to comment, comment count
             showCommentsAccordion(solutionView.solution)
 
         }

--- a/src/main/kotlin/com/physman/templates/Task.kt
+++ b/src/main/kotlin/com/physman/templates/Task.kt
@@ -26,9 +26,8 @@ fun FlowContent.taskTemplate(taskView: TaskView) {
         }
 
 
-        imageAttachmentTemplate(images)
+        galleryTemplate("gallery-${taskView.task.id}", images)
         nonImageAttachmentTemplate(nonImageAttachments)
-        // TODO: Hiding comments, button to comment
         showCommentsAccordion(taskView.task)
     }
 }


### PR DESCRIPTION
- add fancybox js and css dependencies from CDN,
- create fancybox configuration script in the templates/General.kt
- convert images into fancybox galleries
- remove previously completed TODO's related to comments.