### PR TITLE
Bring back the submit indicator in modals.

### DIFF
--- a/src/main/kotlin/com/physman/templates/ModalTemplate.kt
+++ b/src/main/kotlin/com/physman/templates/ModalTemplate.kt
@@ -29,6 +29,9 @@ private fun FlowContent.modalContent(title: String, submitText: String, submitAt
 
             button {
                 attributes.putAll(submitAttributes)
+                span(classes = "htmx-indicator") {
+                    attributes["aria-busy"] = "true"
+                }
                 +submitText
             }
         }


### PR DESCRIPTION
It disappeared after creating the general ModalTemplate