### PR TITLE
Input autofocus

### DIFF
--- a/src/main/kotlin/com/physman/forms/Form.kt
+++ b/src/main/kotlin/com/physman/forms/Form.kt
@@ -125,6 +125,14 @@ class Form(
     ) {
 
         val formScript = """
+            on load 1
+                set firstInput to first <input/> in me
+                if firstInput
+                    call firstInput.focus()
+                    if firstInput.value
+                        call firstInput.setSelectionRange(0, firstInput.value.length)
+                end
+            end
             on htmx:beforeRequest
                 if event.srcElement is me
                     repeat for input in .confirmation-input


### PR DESCRIPTION
- autofocus the first input tag in a form,
- select the text inside the input if present.