### PR TITLE
Attachment and Group editing

### DIFF
--- a/src/main/kotlin/com/studyshare/comment/CommentRepository.kt
+++ b/src/main/kotlin/com/studyshare/comment/CommentRepository.kt
@@ -3,7 +3,7 @@ package com.studyshare.comment
 import org.bson.types.ObjectId
 
 interface CommentRepository {
-    suspend fun getComment(id: ObjectId): Comment?
+    suspend fun getComment(id: ObjectId): Comment
     suspend fun getComments(parentId: ObjectId): List<Comment>
     suspend fun createComment(comment: Comment)
     suspend fun deleteComment(id: ObjectId)

--- a/src/main/kotlin/com/studyshare/comment/MongoCommentRepository.kt
+++ b/src/main/kotlin/com/studyshare/comment/MongoCommentRepository.kt
@@ -2,11 +2,11 @@ package com.studyshare.comment
 
 import com.mongodb.client.model.Filters
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
+import com.studyshare.utils.ResourceNotFoundException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.types.ObjectId
 
-// TODO: error handling
 class MongoCommentRepository(
     mongoDatabase: MongoDatabase,
 ) : CommentRepository {
@@ -14,9 +14,9 @@ class MongoCommentRepository(
     private val commentCollection = mongoDatabase.getCollection<Comment>("comments")
 
 
-    override suspend fun getComment(id: ObjectId): Comment? {
+    override suspend fun getComment(id: ObjectId): Comment {
         val filter = Filters.eq("_id", id)
-        return commentCollection.find(filter).firstOrNull()
+        return commentCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }
 
     override suspend fun getComments(parentId: ObjectId): List<Comment> {
@@ -29,13 +29,11 @@ class MongoCommentRepository(
     }
 
     override suspend fun deleteComment(id: ObjectId) {
-        commentCollection.findOneAndDelete(Filters.eq("_id", id))
+        commentCollection.deleteOne(Filters.eq("_id", id))
     }
 
     override suspend fun deleteComments(parentId: ObjectId) {
         val filter = Filters.eq(Comment::parentId.name, parentId)
         commentCollection.deleteMany(filter)
     }
-
-
 }

--- a/src/main/kotlin/com/studyshare/forms/FileDeletionInput.kt
+++ b/src/main/kotlin/com/studyshare/forms/FileDeletionInput.kt
@@ -1,0 +1,91 @@
+package com.studyshare.forms
+
+import com.studyshare.attachment.AttachmentView
+import kotlinx.html.FlowContent
+import kotlinx.html.*
+import org.bson.types.ObjectId
+
+class FileDeletionInput(
+    val inputName: String,
+    private val inputId: String,
+) : ControlledInput {
+
+    private fun FlowContent.deletionButton(attachmentId: ObjectId, deletedCountId: String) {
+        button(classes = "file-deletion-btn btn secondary danger", type = ButtonType.button) {
+            attributes["_"] = """
+                on click
+                    set input to the next <input/>
+                    call appendValue(input, "$attachmentId")
+                    remove closest parent <div/>
+                    set deletedCount to #$deletedCountId
+                    call incContent(deletedCount)
+            """.trimIndent()
+
+            span(classes = "material-symbols-rounded") {
+                +"delete"
+            }
+        }
+    }
+
+    private fun FlowContent.nonImageFileToBeDeleted(attachmentView: AttachmentView, deletedCountId: String) {
+        div(classes = "non-img-to-be-deleted") {
+            span {
+                +attachmentView.attachment.originalFilename
+            }
+            deletionButton(attachmentView.attachment.id, deletedCountId)
+        }
+    }
+
+    private fun FlowContent.imageFileToBeDeleted(attachmentView: AttachmentView, inputName: String, deletedCountId: String) {
+        div(classes = "img-to-be-deleted") {
+            a(href = attachmentView.url) {
+                attributes["data-fancybox"] = inputName
+                img(
+                    src = attachmentView.thumbnailUrl,
+                    alt = attachmentView.attachment.originalFilename
+                )
+            }
+            deletionButton(attachmentView.attachment.id, deletedCountId)
+        }
+
+    }
+
+    fun render(flowContent: FlowContent, filesToBeDeleted: List<AttachmentView>?) {
+        if (filesToBeDeleted.isNullOrEmpty()) {
+            return
+        }
+
+        val imageAttachments = filesToBeDeleted.filter { it.attachment.isImage }
+        val nonImageAttachments = filesToBeDeleted.filter { !it.attachment.isImage}
+
+        val deletedCountId = "$inputId-deleted-count"
+
+        flowContent.div {
+            section(classes = "gallery") {
+                imageAttachments.forEach {
+                    imageFileToBeDeleted(it, inputName, deletedCountId)
+                }
+            }
+
+            section {
+                nonImageAttachments.forEach {
+                    nonImageFileToBeDeleted(it, deletedCountId)
+                }
+            }
+
+            p(classes = "deleted-count-text") {
+                +"Deleted "
+                span {
+                    attributes["id"] = deletedCountId
+                    +"0"
+                }
+                +" attachment(s)"
+            }
+
+            input(type = InputType.hidden) {
+                attributes["name"] = inputName
+                attributes["id"]
+            }
+       }
+    }
+}

--- a/src/main/kotlin/com/studyshare/forms/FileInput.kt
+++ b/src/main/kotlin/com/studyshare/forms/FileInput.kt
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets
 class FileInput(
     private val inputLabel: String,
     private val inputName: String,
-    private val maxFileCount: Int = 1,
     private val inputAttributes: Map<String, String>? = null
 ) : ControlledInput {
 
@@ -25,9 +24,6 @@ class FileInput(
             }
             input(type = InputType.file, name = inputName) {
                 attributes["id"] = inputName
-                if (maxFileCount > 1) {
-                    attributes["multiple"] = "true"
-                }
                 if (inputAttributes != null) {
                     attributes.putAll(inputAttributes)
                 }

--- a/src/main/kotlin/com/studyshare/group/GroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupRepository.kt
@@ -5,11 +5,11 @@ import org.bson.types.ObjectId
 
 interface GroupRepository {
     suspend fun createGroup(group: Group, groupThumbnailFile: UploadFileData?): GroupView
-    suspend fun deleteGroup(groupId: ObjectId)
+    suspend fun deleteGroup(groupId: ObjectId, userId: ObjectId)
     suspend fun addUser(groupId: ObjectId, userId: ObjectId)
     suspend fun isUserMember(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun isUserGroupLeader(groupId: ObjectId, userId: ObjectId): Boolean
-    suspend fun deleteUser(groupId: ObjectId, userId: ObjectId)
+    suspend fun deleteUser(groupId: ObjectId, userId: ObjectId, targetUserId: ObjectId)
     suspend fun getGroupView(groupId: ObjectId): GroupView
     suspend fun getGroupViews(groupIds: List<ObjectId>): List<GroupView>
     suspend fun addTaskCategory(groupId: ObjectId, taskCategory: String)

--- a/src/main/kotlin/com/studyshare/group/GroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupRepository.kt
@@ -10,8 +10,8 @@ interface GroupRepository {
     suspend fun isUserMember(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun isUserGroupLeader(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun deleteUser(groupId: ObjectId, userId: ObjectId)
-    suspend fun getGroup(groupId: ObjectId): GroupView
-    suspend fun getGroups(groupIds: List<ObjectId>): List<GroupView>
+    suspend fun getGroupView(groupId: ObjectId): GroupView
+    suspend fun getGroupViews(groupIds: List<ObjectId>): List<GroupView>
     suspend fun addTaskCategory(groupId: ObjectId, taskCategory: String)
     suspend fun removeTaskCategory(groupId: ObjectId, taskCategory: String)
 }

--- a/src/main/kotlin/com/studyshare/group/GroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupRepository.kt
@@ -10,6 +10,7 @@ interface GroupRepository {
     suspend fun isUserMember(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun isUserGroupLeader(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun deleteUser(groupId: ObjectId, userId: ObjectId, targetUserId: ObjectId)
+    suspend fun getGroup(groupId: ObjectId): Group
     suspend fun getGroupView(groupId: ObjectId): GroupView
     suspend fun getGroupViews(groupIds: List<ObjectId>): List<GroupView>
     suspend fun addTaskCategory(groupId: ObjectId, taskCategory: String)

--- a/src/main/kotlin/com/studyshare/group/GroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupRepository.kt
@@ -10,7 +10,7 @@ interface GroupRepository {
     suspend fun isUserMember(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun isUserGroupLeader(groupId: ObjectId, userId: ObjectId): Boolean
     suspend fun deleteUser(groupId: ObjectId, userId: ObjectId)
-    suspend fun getGroup(groupId: ObjectId): GroupView?
+    suspend fun getGroup(groupId: ObjectId): GroupView
     suspend fun getGroups(groupIds: List<ObjectId>): List<GroupView>
     suspend fun addTaskCategory(groupId: ObjectId, taskCategory: String)
     suspend fun removeTaskCategory(groupId: ObjectId, taskCategory: String)

--- a/src/main/kotlin/com/studyshare/group/GroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupRepository.kt
@@ -14,4 +14,5 @@ interface GroupRepository {
     suspend fun getGroupViews(groupIds: List<ObjectId>): List<GroupView>
     suspend fun addTaskCategory(groupId: ObjectId, taskCategory: String)
     suspend fun removeTaskCategory(groupId: ObjectId, taskCategory: String)
+    suspend fun editGroup(groupId: ObjectId, userId: ObjectId, groupUpdates: GroupUpdates): GroupView
 }

--- a/src/main/kotlin/com/studyshare/group/GroupUpdates.kt
+++ b/src/main/kotlin/com/studyshare/group/GroupUpdates.kt
@@ -1,0 +1,9 @@
+package com.studyshare.group
+
+import com.studyshare.forms.UploadFileData
+
+class GroupUpdates(
+    val title: String? = null,
+    val description: String? = null,
+    val newThumbnail: UploadFileData? = null
+)

--- a/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
@@ -21,7 +21,7 @@ class MongoGroupRepository(
 
     private val groupCollection = database.getCollection<Group>("groups")
 
-    private suspend fun getGroup(groupId: ObjectId): Group {
+    override suspend fun getGroup(groupId: ObjectId): Group {
         val filter = Filters.eq("_id", groupId)
         return groupCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }

--- a/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
@@ -8,6 +8,7 @@ import com.studyshare.attachment.AttachmentRepository
 import com.studyshare.authentication.user.UserRepository
 import com.studyshare.forms.UploadFileData
 import com.studyshare.task.TaskRepository
+import com.studyshare.utils.ResourceNotFoundException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.types.ObjectId
@@ -70,8 +71,8 @@ class MongoGroupRepository(
         return group.leaderId == userId
     }
 
-    override suspend fun getGroup(groupId: ObjectId): GroupView? {
-        val group = groupCollection.find(Filters.eq("_id", groupId)).firstOrNull() ?: return null
+    override suspend fun getGroup(groupId: ObjectId): GroupView {
+        val group = groupCollection.find(Filters.eq("_id", groupId)).firstOrNull() ?: throw ResourceNotFoundException()
         return GroupView(
             group = group,
             thumbnail = group.thumbnailId?.let { attachmentRepository.getAttachment(it) }

--- a/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
+++ b/src/main/kotlin/com/studyshare/group/MongoGroupRepository.kt
@@ -71,7 +71,7 @@ class MongoGroupRepository(
         return group.leaderId == userId
     }
 
-    override suspend fun getGroup(groupId: ObjectId): GroupView {
+    override suspend fun getGroupView(groupId: ObjectId): GroupView {
         val group = groupCollection.find(Filters.eq("_id", groupId)).firstOrNull() ?: throw ResourceNotFoundException()
         return GroupView(
             group = group,
@@ -79,7 +79,7 @@ class MongoGroupRepository(
         )
     }
 
-    override suspend fun getGroups(groupIds: List<ObjectId>): List<GroupView> {
+    override suspend fun getGroupViews(groupIds: List<ObjectId>): List<GroupView> {
         val filter = Filters.`in`("_id", groupIds)
         val sort = Sorts.descending("_id")
         return groupCollection.find(filter).sort(sort).toList().map { group: Group ->

--- a/src/main/kotlin/com/studyshare/post/Post.kt
+++ b/src/main/kotlin/com/studyshare/post/Post.kt
@@ -1,4 +1,4 @@
-package com.studyshare.utils
+package com.studyshare.post
 
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId

--- a/src/main/kotlin/com/studyshare/routes/Comment.kt
+++ b/src/main/kotlin/com/studyshare/routes/Comment.kt
@@ -9,7 +9,7 @@ import com.studyshare.solution.SolutionRepository
 import com.studyshare.task.TaskRepository
 import com.studyshare.templates.commentCountTemplate
 import com.studyshare.templates.commentTemplate
-import com.studyshare.utils.Post
+import com.studyshare.post.Post
 import com.studyshare.utils.ResourceNotFoundException
 import com.studyshare.utils.validateGroupBelonging
 import com.studyshare.utils.validateRequiredObjectIds

--- a/src/main/kotlin/com/studyshare/routes/Comment.kt
+++ b/src/main/kotlin/com/studyshare/routes/Comment.kt
@@ -41,8 +41,8 @@ fun Route.getCommentView(taskRepository: TaskRepository, solutionRepository: Sol
         val comments = commentRepository.getComments(parentId!!)
         val parentPost: Post = try {
             when (parentPostClassName.lowercase()) {
-                "task" -> taskRepository.getTask(parentId).task
-                "solution" -> solutionRepository.getSolution(parentId, userId).solution
+                "task" -> taskRepository.getTaskView(parentId).task
+                "solution" -> solutionRepository.getSolutionView(parentId, userId).solution
                 else -> return@get call.respond(HttpStatusCode.BadRequest)
             }
         } catch (e: ResourceNotFoundException) {
@@ -109,8 +109,8 @@ fun Route.postComment(taskRepository: TaskRepository, solutionRepository: Soluti
 
         val parentPost: Post = try {
             when (postType?.lowercase()) {
-                "task" -> taskRepository.getTask(parentId!!).task
-                "solution" -> solutionRepository.getSolution(parentId!!, authorId).solution
+                "task" -> taskRepository.getTaskView(parentId!!).task
+                "solution" -> solutionRepository.getSolutionView(parentId!!, authorId).solution
                 else -> return@post call.respond(HttpStatusCode.BadRequest)
             }
         } catch (e: ResourceNotFoundException) {

--- a/src/main/kotlin/com/studyshare/routes/Group.kt
+++ b/src/main/kotlin/com/studyshare/routes/Group.kt
@@ -5,6 +5,7 @@ import com.studyshare.authentication.user.UserSession
 import com.studyshare.forms.*
 import com.studyshare.group.Group
 import com.studyshare.group.GroupRepository
+import com.studyshare.group.GroupUpdates
 import com.studyshare.solution.additionalNotesValidator
 import com.studyshare.solution.titleValidator
 import com.studyshare.templates.*
@@ -21,6 +22,7 @@ import org.bson.types.ObjectId
 fun Route.groupRouter(groupRepository: GroupRepository, userRepository: UserRepository) {
     val groupCreationForm = routeGroupCreationForm()
     val userAdditionForm = routeUserAdditionForm()
+    val groupEditionForm = routeGroupEditionForm()
     route("/groups") {
         getGroupList(groupRepository, userRepository)
         postCreateGroup(groupRepository, groupCreationForm)
@@ -30,7 +32,11 @@ fun Route.groupRouter(groupRepository: GroupRepository, userRepository: UserRepo
     }
     route("/{groupId}") {
         getGroupView(groupRepository)
+        patchGroupEditing(groupRepository, groupEditionForm)
         deleteGroup(groupRepository)
+        route("/edition-modal") {
+            getGroupEditionModal(groupEditionForm, groupRepository)
+        }
         route("/add-user") {
             getAddUserToGroupModal(userAdditionForm)
             postAddUserToGroup(groupRepository, userRepository, userAdditionForm)
@@ -55,16 +61,29 @@ fun Route.groupRouter(groupRepository: GroupRepository, userRepository: UserRepo
 fun routeGroupCreationForm(): Form {
     val groupCreationForm = Form("Create a new group", "groupForm", formAttributes = mapOf(
         "hx-swap" to "none"
-    )
-    )
+    ))
 
     groupCreationForm.addInput(TextlikeInput("Title", "title", InputType.text, titleValidator))
     groupCreationForm.addInput(TextlikeInput("Description", "description", InputType.text, additionalNotesValidator))
-    groupCreationForm.addInput(FileInput("Thumbnail", "image", inputAttributes = mapOf("multiple" to "false")))
+    groupCreationForm.addInput(FileInput("Thumbnail", "image"))
 
     globalFormRouter.routeFormValidators(groupCreationForm)
 
     return groupCreationForm
+}
+
+fun routeGroupEditionForm(): Form {
+    val groupEditionForm = Form("Edit your Group", "groupEditionForm", formAttributes = mapOf(
+        "hx-swap" to "outerHTML"
+    ))
+
+    groupEditionForm.addInput(TextlikeInput("Title", "title", InputType.text, titleValidator))
+    groupEditionForm.addInput(TextlikeInput("Description", "description", InputType.text, additionalNotesValidator))
+    groupEditionForm.addInput(FileInput("Select a new thumbnail", "image"))
+
+    globalFormRouter.routeFormValidators(groupEditionForm)
+
+    return groupEditionForm
 }
 
 val nonEmptyValidator = fun(title: String): String? {
@@ -94,6 +113,37 @@ fun Route.getGroupCreationModal(groupCreationForm: Form) {
                 formModalDialog(
                     form = groupCreationForm,
                     callbackUrl = "/groups"
+                )
+            }
+        }
+    }
+}
+
+fun Route.getGroupEditionModal(groupEditionForm: Form, groupRepository: GroupRepository) {
+    get {
+        val validatedObjectIds = validateRequiredObjectIds(call, "groupId") ?: return@get
+        val groupId = validatedObjectIds["groupId"]!!
+        
+        val group = try {
+            groupRepository.getGroup(groupId)
+        } catch (e: ResourceNotFoundException) {
+            call.respondText("Group not found.", status = HttpStatusCode.NotFound)
+            return@get
+        }
+
+        call.respondHtml {
+            body {
+                formModalDialog(
+                    form = groupEditionForm,
+                    callbackUrl = "/$groupId",
+                    requestType = HtmxRequestType.PATCH,
+                    extraAttributes = mapOf(
+                        "hx-target" to "#group-header-${group.id}"
+                    ),
+                    inputValues = mapOf(
+                        "title" to group.title,
+                        "description" to (group.description ?: "")
+                    )
                 )
             }
         }
@@ -239,6 +289,44 @@ fun Route.postAddUserToGroup(groupRepository: GroupRepository, userRepository: U
         groupRepository.addUser(groupId, userToAdd.id)
 
         call.respondRedirect("/${groupId}")
+    }
+}
+
+fun Route.patchGroupEditing(groupRepository: GroupRepository, groupEditionForm: Form) {
+    patch {
+        val objectIds = validateRequiredObjectIds(call, "groupId") ?: return@patch
+        val groupId = objectIds["groupId"]!!
+
+        val userSession = call.sessions.get<UserSession>()!!
+        val userId = ObjectId(userSession.id)
+
+        val formSubmissionData: FormSubmissionData = groupEditionForm.validateSubmission(call) ?: return@patch
+        val title = formSubmissionData.fields["title"]!!
+        val description = formSubmissionData.fields["description"]!!
+
+        val solutionUpdates = GroupUpdates(
+            title = title,
+            description = description,
+            newThumbnail = formSubmissionData.files.firstOrNull()
+        )
+
+        val updatedGroupView = try {
+            groupRepository.editGroup(groupId, userId, solutionUpdates)
+        } catch (e: ResourceNotFoundException) {
+            call.respondText("Group not found.", status = HttpStatusCode.NotFound)
+            return@patch
+        } catch (e: ResourceModificationRestrictedException) {
+            call.respondText("Group modification forbidden.", status = HttpStatusCode.Forbidden)
+            return@patch
+        } finally {
+            formSubmissionData.cleanup()
+        }
+
+        call.respondHtml(HttpStatusCode.OK) {
+            body {
+                groupHeader(updatedGroupView, userSession)
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/com/studyshare/routes/Group.kt
+++ b/src/main/kotlin/com/studyshare/routes/Group.kt
@@ -107,7 +107,7 @@ fun Route.getGroupList(groupRepository: GroupRepository, userRepository: UserRep
     get {
         val userSession = call.sessions.get<UserSession>()!!
         val groupIds = userRepository.getUserById(userSession.id)?.groupIds ?: emptySet()
-        val groupViews = groupRepository.getGroups(groupIds.toList())
+        val groupViews = groupRepository.getGroupViews(groupIds.toList())
 
         call.respondHtml {
             body {
@@ -130,7 +130,7 @@ fun Route.getGroupView(groupRepository: GroupRepository) {
         val groupId = objectIds["groupId"]!!
 
         val groupView = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Group not found.", status = HttpStatusCode.NotFound)
             return@get
@@ -158,7 +158,7 @@ fun Route.getUsersModal(groupRepository: GroupRepository, userRepository: UserRe
         val userId = userSession.id
 
         val groupView = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Group not found.", status = HttpStatusCode.NotFound)
             return@get
@@ -289,7 +289,7 @@ fun Route.deleteUserFromGroup(groupRepository: GroupRepository) {
         val userId = ObjectId(userSession.id)
 
         val groupView = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Group not found.", status = HttpStatusCode.NotFound)
             return@delete
@@ -338,7 +338,7 @@ fun Route.deleteGroup(groupRepository: GroupRepository) {
         val userId = ObjectId(userSession.id)
 
         val groupView = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Group not found.", status = HttpStatusCode.NotFound)
             return@delete

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -255,8 +255,6 @@ fun Route.patchSolutionEditing(solutionRepository: SolutionRepository, solutionE
             return@patch
         }
 
-        println(filesToDelete)
-
         val solutionUpdates = SolutionUpdates(
             title = title,
             additionalNotes = additionalNotes,

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -329,6 +329,7 @@ fun Route.postVote(solutionRepository: SolutionRepository, groupRepository: Grou
         val solutionView = try {
             solutionRepository.getSolution(solutionId, userId)
         } catch (e: ResourceNotFoundException) {
+            call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
             return@post
         }
         if (!validateGroupBelonging(call, groupRepository, solutionView.solution.groupId)) return@post
@@ -347,7 +348,12 @@ fun Route.postVote(solutionRepository: SolutionRepository, groupRepository: Grou
             }
         }
 
-        val voteUpdate = solutionRepository.vote(solutionId, userId, voteType) ?: return@post
+        val voteUpdate = try {
+            solutionRepository.vote(solutionId, userId, voteType)
+        } catch (e: ResourceNotFoundException) {
+            call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
+            return@post
+        }
 
         call.respondHtml(HttpStatusCode.OK) {
             body {

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -269,7 +269,6 @@ fun Route.patchSolutionEditing(solutionRepository: SolutionRepository, solutionE
             return@patch
         } catch (e: ResourceModificationRestrictedException) {
             call.respondText("Solution modification forbidden.", status = HttpStatusCode.Forbidden)
-            formSubmissionData.cleanup()
             return@patch
         } finally {
             formSubmissionData.cleanup()

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -248,11 +248,11 @@ fun Route.patchSolutionEditing(solutionRepository: SolutionRepository, solutionE
         val additionalNotes = formSubmissionData.fields["additionalNotes"]!!
         val deletedFiles = formSubmissionData.fields["deletedFiles"]!!
 
-        val filesToDelete = parseObjectIdList(deletedFiles.dropLast(1).split(";"))
-
-        if (filesToDelete == null) {
-            call.respondText("Invalid value passed for the deletedFiles argument")
-            return@patch
+        val filesToDelete = if (deletedFiles.isNotEmpty()) {
+            parseObjectIdList(deletedFiles.dropLast(1).split(";")) ?:
+                return@patch call.respondText("Invalid value passed for the deletedFiles argument")
+        } else {
+            emptyList()
         }
 
         val solutionUpdates = SolutionUpdates(

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -300,15 +300,14 @@ fun Route.deleteSolution(solutionRepository: SolutionRepository, taskRepository:
             return@delete
         }
 
-        val parentAuthorId = parentTask.task.authorId
-        val authorId = solutionView.solution.authorId
-
-        if (authorId == userId || parentAuthorId == userId) {
-            solutionRepository.deleteSolution(solutionId)
+        try {
+            solutionRepository.deleteSolution(solutionId, userId, parentTask.task)
             call.respondHtml { body() }
-        }
-        else {
-            call.respondText("Resource Modification Restricted - Ownership Required", status = HttpStatusCode.Forbidden)
+        } catch (e: ResourceNotFoundException) {
+            call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
+            return@delete
+        } catch (e: ResourceModificationRestrictedException) {
+            call.respondText("Solution deletion forbidden.", status = HttpStatusCode.NotFound)
             return@delete
         }
     }

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -288,23 +288,11 @@ fun Route.deleteSolution(solutionRepository: SolutionRepository, taskRepository:
         val solutionId = objectIds["id"]!!
         val userId = ObjectId(call.sessions.get<UserSession>()!!.id)
 
-        val solutionView = try {
-            solutionRepository.getSolutionView(solutionId, userId)
-        } catch (e: ResourceNotFoundException) {
-            return@delete
-        }
-        val parentTask = try {
-            taskRepository.getTaskView(solutionView.solution.taskId)
-        } catch (e: ResourceNotFoundException) {
-            call.respondText("Associated Task not found.", status = HttpStatusCode.NotFound)
-            return@delete
-        }
-
         try {
-            solutionRepository.deleteSolution(solutionId, userId, parentTask.task)
+            solutionRepository.deleteSolution(solutionId, userId, taskRepository)
             call.respondHtml { body() }
         } catch (e: ResourceNotFoundException) {
-            call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
+            call.respondText("Solution or the parent Task not found.", status = HttpStatusCode.NotFound)
             return@delete
         } catch (e: ResourceModificationRestrictedException) {
             call.respondText("Solution deletion forbidden.", status = HttpStatusCode.Forbidden)

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -101,7 +101,7 @@ fun Route.getSolutionEditingModal(solutionEditingForm: Form, solutionRepository:
         }
 
         val solutionView = try {
-            solutionRepository.getSolution(ObjectId(id), userId)
+            solutionRepository.getSolutionView(ObjectId(id), userId)
         } catch (e: ResourceNotFoundException) {
             return@get
         }
@@ -167,7 +167,7 @@ fun Route.getSolutions(taskRepository: TaskRepository, solutionRepository: Solut
         val userId = ObjectId(userSession.id)
 
         val parentTask = try {
-            taskRepository.getTask(taskId)
+            taskRepository.getTaskView(taskId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Associated Task not found.", status = HttpStatusCode.NotFound)
             return@get
@@ -176,7 +176,7 @@ fun Route.getSolutions(taskRepository: TaskRepository, solutionRepository: Solut
 
         if (!validateGroupBelonging(call, groupRepository, parentTask.task.groupId)) return@get
 
-        val solutionViews = solutionRepository.getSolutions(
+        val solutionViews = solutionRepository.getSolutionViews(
             taskId = taskId, userId = userId, lastId = lastId, resultCount = pageSize
         )
 
@@ -214,7 +214,7 @@ fun Route.postSolutionCreation(taskRepository: TaskRepository, solutionRepositor
         val additionalNotes = formSubmissionData.fields["additionalNotes"]!!
 
         val task = try {
-            taskRepository.getTask(taskId)
+            taskRepository.getTaskView(taskId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Associated Task not found.", status = HttpStatusCode.NotFound)
             return@post
@@ -290,12 +290,12 @@ fun Route.deleteSolution(solutionRepository: SolutionRepository, taskRepository:
         val userId = ObjectId(call.sessions.get<UserSession>()!!.id)
 
         val solutionView = try {
-            solutionRepository.getSolution(solutionId, userId)
+            solutionRepository.getSolutionView(solutionId, userId)
         } catch (e: ResourceNotFoundException) {
             return@delete
         }
         val parentTask = try {
-            taskRepository.getTask(solutionView.solution.taskId)
+            taskRepository.getTaskView(solutionView.solution.taskId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Associated Task not found.", status = HttpStatusCode.NotFound)
             return@delete
@@ -325,7 +325,7 @@ fun Route.postVote(solutionRepository: SolutionRepository, groupRepository: Grou
         val userId = ObjectId(userSession.id)
 
         val solutionView = try {
-            solutionRepository.getSolution(solutionId, userId)
+            solutionRepository.getSolutionView(solutionId, userId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
             return@post

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -241,18 +241,21 @@ fun Route.patchSolutionEditing(solutionRepository: SolutionRepository, solutionE
             return@patch
         }
 
-        val newSolution = previousSolution.solution.copy(
+        val solutionUpdates = SolutionUpdates(
             title = title,
             additionalNotes = additionalNotes
         )
 
-        solutionRepository.updateSolution(solutionId, newSolution)
+        val updatedSolutionView = solutionRepository.updateSolution(solutionId, userId, solutionUpdates)
 
-        val newSolutionView = SolutionView(newSolution, previousSolution.attachments, previousSolution.isUpvoted, previousSolution.isDownvoted)
+        if (updatedSolutionView == null) {
+            call.respondText("Solution not found", status = HttpStatusCode.NotFound)
+            return@patch
+        }
 
         call.respondHtml(HttpStatusCode.OK) {
             body {
-                solutionTemplate(newSolutionView, AccessLevel.EDIT)
+                solutionTemplate(updatedSolutionView, AccessLevel.EDIT)
             }
         }
     }

--- a/src/main/kotlin/com/studyshare/routes/Solution.kt
+++ b/src/main/kotlin/com/studyshare/routes/Solution.kt
@@ -307,7 +307,7 @@ fun Route.deleteSolution(solutionRepository: SolutionRepository, taskRepository:
             call.respondText("Solution not found.", status = HttpStatusCode.NotFound)
             return@delete
         } catch (e: ResourceModificationRestrictedException) {
-            call.respondText("Solution deletion forbidden.", status = HttpStatusCode.NotFound)
+            call.respondText("Solution deletion forbidden.", status = HttpStatusCode.Forbidden)
             return@delete
         }
     }

--- a/src/main/kotlin/com/studyshare/routes/Task.kt
+++ b/src/main/kotlin/com/studyshare/routes/Task.kt
@@ -329,7 +329,7 @@ fun Route.deleteTask(taskRepository: TaskRepository, groupRepository: GroupRepos
             call.respondText("Task not found.", status = HttpStatusCode.NotFound)
             return@delete
         } catch (e: ResourceModificationRestrictedException) {
-            call.respondText("Task modification forbidden.", status = HttpStatusCode.Forbidden)
+            call.respondText("Task deletion forbidden.", status = HttpStatusCode.Forbidden)
             return@delete
         }
 

--- a/src/main/kotlin/com/studyshare/routes/Task.kt
+++ b/src/main/kotlin/com/studyshare/routes/Task.kt
@@ -52,7 +52,7 @@ fun Route.getTaskView(taskRepository: TaskRepository, groupRepository: GroupRepo
         val groupId = objectIds["groupId"]!!
 
         val taskView = try {
-            taskRepository.getTask(taskId)
+            taskRepository.getTaskView(taskId)
         } catch (e: ResourceNotFoundException) {
             call.respondText(text = "Task not found.", status = HttpStatusCode.NotFound)
             return@get
@@ -157,7 +157,7 @@ fun Route.getTaskCreationModal(taskCreationForm: Form, groupRepository: GroupRep
         val groupId = validateRequiredObjectIds(call, "groupId")?.get("groupId") ?: return@get
 
         val groupView = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText(text = "Group does not exist.", status = HttpStatusCode.NotFound)
             return@get
@@ -185,7 +185,7 @@ fun Route.getTaskEditingModal(taskEditingForm: Form, taskRepository: TaskReposit
         }
 
         val taskView = try {
-            taskRepository.getTask(ObjectId(id))
+            taskRepository.getTaskView(ObjectId(id))
         } catch (e: ResourceNotFoundException) {
             call.respondText("Task not found.", status = HttpStatusCode.NotFound)
             return@get
@@ -243,7 +243,7 @@ fun Route.postTaskCreation(taskRepository: TaskRepository, groupRepository: Grou
 
         val groupId = validateRequiredObjectIds(call, "groupId")?.get("groupId") ?: return@post
         val group = try {
-            groupRepository.getGroup(groupId)
+            groupRepository.getGroupView(groupId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Group not found.", status = HttpStatusCode.NotFound)
             return@post
@@ -290,7 +290,7 @@ fun Route.patchTaskEditing(taskRepository: TaskRepository, taskEditingForm: Form
         }
 
         val previousTask = try {
-            taskRepository.getTask(taskId)
+            taskRepository.getTaskView(taskId)
         } catch (e: ResourceNotFoundException) {
             call.respondText("Task not found.", status = HttpStatusCode.NotFound)
             return@patch
@@ -331,7 +331,7 @@ fun Route.deleteTask(taskRepository: TaskRepository, groupRepository: GroupRepos
         val taskId = objectIds["taskId"]!!
 
         val task = try {
-            taskRepository.getTask(taskId).task
+            taskRepository.getTaskView(taskId).task
         } catch (e: ResourceNotFoundException) {
             call.respondText("Task not found.", status = HttpStatusCode.NotFound)
             return@delete

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -5,8 +5,8 @@ import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.studyshare.attachment.AttachmentRepository
 import com.studyshare.comment.CommentRepository
 import com.studyshare.forms.UploadFileData
-import com.studyshare.utils.PostModificationRestrictedException
-import com.studyshare.utils.PostNotFoundException
+import com.studyshare.utils.ResourceModificationRestrictedException
+import com.studyshare.utils.ResourceNotFoundException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.conversions.Bson
@@ -51,10 +51,10 @@ class MongoSolutionRepository(
 
         val filter = Filters.eq("_id", id)
 
-        val solution = solutionCollection.find(filter).firstOrNull() ?: throw PostNotFoundException()
+        val solution = solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
 
         if (solution.authorId != userId) {
-            throw PostModificationRestrictedException()
+            throw ResourceModificationRestrictedException()
         }
 
         val updatedAttachments = solution.attachmentIds + newAttachments.map { it.attachment.id } - solutionUpdates.filesToDelete.toSet()
@@ -68,7 +68,7 @@ class MongoSolutionRepository(
         )
 
         val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
-        val updatedSolution = solutionCollection.findOneAndUpdate(filter, updates, options) ?: throw PostNotFoundException()
+        val updatedSolution = solutionCollection.findOneAndUpdate(filter, updates, options) ?: throw ResourceNotFoundException()
 
         return createSolutionView(userId, updatedSolution)
     }
@@ -106,7 +106,7 @@ class MongoSolutionRepository(
 
     override suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView {
         val filter = Filters.eq("_id", solutionId)
-        val solution = solutionCollection.find(filter).firstOrNull() ?: throw PostNotFoundException()
+        val solution = solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
         return createSolutionView(userId, solution)
     }
 

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -28,7 +28,7 @@ class MongoSolutionRepository(
         isDownvoted = solution.downvotes.contains(userId)
     )
 
-    suspend fun getSolution(id: ObjectId): Solution {
+    private suspend fun getSolution(id: ObjectId): Solution {
         val filter = Filters.eq("_id", id)
         return solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }
@@ -63,11 +63,9 @@ class MongoSolutionRepository(
         val updatedAttachments = solution.attachmentIds + newAttachments.map { it.attachment.id } - solutionUpdates.filesToDelete.toSet()
 
         val updates = Updates.combine(
-            listOfNotNull(
-                Updates.set(Solution::title.name, solutionUpdates.title),
-                Updates.set(Solution::additionalNotes.name, solutionUpdates.additionalNotes),
-                Updates.set(Solution::attachmentIds.name, updatedAttachments)
-            )
+            Updates.set(Solution::title.name, solutionUpdates.title),
+            Updates.set(Solution::additionalNotes.name, solutionUpdates.additionalNotes),
+            Updates.set(Solution::attachmentIds.name, updatedAttachments)
         )
 
         val filter = Filters.eq("_id", id)

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -110,8 +110,6 @@ class MongoSolutionRepository(
         return createSolutionView(userId, solution)
     }
 
-
-
     override suspend fun updateCommentAmount(solutionId: ObjectId, amount: Int): Int {
         val filter = Filters.eq("_id", solutionId)
         val updates = Updates.inc(Solution::commentAmount.name, amount)

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -5,7 +5,7 @@ import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.studyshare.attachment.AttachmentRepository
 import com.studyshare.comment.CommentRepository
 import com.studyshare.forms.UploadFileData
-import com.studyshare.task.Task
+import com.studyshare.task.TaskRepository
 import com.studyshare.utils.ResourceModificationRestrictedException
 import com.studyshare.utils.ResourceNotFoundException
 import kotlinx.coroutines.flow.firstOrNull
@@ -75,9 +75,10 @@ class MongoSolutionRepository(
         return createSolutionView(userId, updatedSolution)
     }
 
-    override suspend fun deleteSolution(id: ObjectId, userId: ObjectId, parentTask: Task) {
+    override suspend fun deleteSolution(id: ObjectId, userId: ObjectId, taskRepository: TaskRepository) {
 
         val solution = getSolution(id)
+        val parentTask = taskRepository.getTask(solution.taskId)
 
         if (solution.authorId != userId && parentTask.authorId != userId) {
             throw ResourceModificationRestrictedException()

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -28,8 +28,8 @@ class MongoSolutionRepository(
         isDownvoted = solution.downvotes.contains(userId)
     )
 
-    private suspend fun getSolution(id: ObjectId): Solution {
-        val filter = Filters.eq("_id", id)
+    private suspend fun getSolution(solutionId: ObjectId): Solution {
+        val filter = Filters.eq("_id", solutionId)
         return solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }
 

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -116,14 +116,14 @@ class MongoSolutionRepository(
         val filter = Filters.eq("_id", solutionId)
         val updates = Updates.inc(Solution::commentAmount.name, amount)
 
-        val solution = solutionCollection.findOneAndUpdate(filter, updates) ?: return 0
+        val solution = solutionCollection.findOneAndUpdate(filter, updates) ?: throw ResourceNotFoundException()
 
         return solution.commentAmount + 1
     }
 
-    override suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate? {
+    override suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate {
         val filter = Filters.eq("_id", id)
-        val solution = solutionCollection.find(filter).firstOrNull() ?: return null
+        val solution = solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
 
         val removeDownvote = Updates.pull(Solution::downvotes.name, userId)
         val removeUpvote = Updates.pull(Solution::upvotes.name, userId)

--- a/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/MongoSolutionRepository.kt
@@ -89,7 +89,7 @@ class MongoSolutionRepository(
         solutionCollection.deleteMany(filter)
     }
 
-    override suspend fun getSolutions(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView> {
+    override suspend fun getSolutionViews(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView> {
         val filter = if (lastId != null) {
             Filters.and(
                 Filters.eq(Solution::taskId.name, taskId),
@@ -104,7 +104,7 @@ class MongoSolutionRepository(
         }
     }
 
-    override suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView {
+    override suspend fun getSolutionView(solutionId: ObjectId, userId: ObjectId): SolutionView {
         val filter = Filters.eq("_id", solutionId)
         val solution = solutionCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
         return createSolutionView(userId, solution)

--- a/src/main/kotlin/com/studyshare/solution/Solution.kt
+++ b/src/main/kotlin/com/studyshare/solution/Solution.kt
@@ -4,7 +4,7 @@ import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 import com.studyshare.task.titleValidator
 import com.studyshare.task.additionalNotesValidator
-import com.studyshare.utils.Post
+import com.studyshare.post.Post
 
 val titleValidator = titleValidator
 val additionalNotesValidator = additionalNotesValidator

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -4,8 +4,8 @@ import com.studyshare.forms.UploadFileData
 import org.bson.types.ObjectId
 
 interface SolutionRepository {
-    suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView
-    suspend fun getSolutions(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView>
+    suspend fun getSolutionView(solutionId: ObjectId, userId: ObjectId): SolutionView
+    suspend fun getSolutionViews(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView>
     suspend fun createSolution(solution: Solution, files: List<UploadFileData>, userId: ObjectId): SolutionView
     suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView
     suspend fun deleteSolutions(taskId: ObjectId)

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -10,8 +10,6 @@ interface SolutionRepository {
     suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView
     suspend fun deleteSolutions(taskId: ObjectId)
     suspend fun deleteSolution(id: ObjectId)
-
     suspend fun updateCommentAmount(solutionId: ObjectId, amount: Int): Int
-
     suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate
 }

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -4,10 +4,10 @@ import com.studyshare.forms.UploadFileData
 import org.bson.types.ObjectId
 
 interface SolutionRepository {
-    suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView?
+    suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView
     suspend fun getSolutions(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView>
     suspend fun createSolution(solution: Solution, files: List<UploadFileData>, userId: ObjectId): SolutionView
-    suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView?
+    suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView
     suspend fun deleteSolutions(taskId: ObjectId)
     suspend fun deleteSolution(id: ObjectId)
 

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -13,5 +13,5 @@ interface SolutionRepository {
 
     suspend fun updateCommentAmount(solutionId: ObjectId, amount: Int): Int
 
-    suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate?
+    suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate
 }

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -1,7 +1,7 @@
 package com.studyshare.solution
 
 import com.studyshare.forms.UploadFileData
-import com.studyshare.task.Task
+import com.studyshare.task.TaskRepository
 import org.bson.types.ObjectId
 
 interface SolutionRepository {
@@ -10,7 +10,7 @@ interface SolutionRepository {
     suspend fun createSolution(solution: Solution, files: List<UploadFileData>, userId: ObjectId): SolutionView
     suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView
     suspend fun deleteSolutions(taskId: ObjectId)
-    suspend fun deleteSolution(id: ObjectId, userId: ObjectId, parentTask: Task)
+    suspend fun deleteSolution(id: ObjectId, userId: ObjectId, taskRepository: TaskRepository)
     suspend fun updateCommentAmount(solutionId: ObjectId, amount: Int): Int
     suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate
 }

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -7,7 +7,7 @@ interface SolutionRepository {
     suspend fun getSolution(solutionId: ObjectId, userId: ObjectId): SolutionView?
     suspend fun getSolutions(taskId: ObjectId, userId: ObjectId, resultCount: Int, lastId: ObjectId?): List<SolutionView>
     suspend fun createSolution(solution: Solution, files: List<UploadFileData>, userId: ObjectId): SolutionView
-    suspend fun updateSolution(id: ObjectId, newSolution: Solution)
+    suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView?
     suspend fun deleteSolutions(taskId: ObjectId)
     suspend fun deleteSolution(id: ObjectId)
 

--- a/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionRepository.kt
@@ -1,6 +1,7 @@
 package com.studyshare.solution
 
 import com.studyshare.forms.UploadFileData
+import com.studyshare.task.Task
 import org.bson.types.ObjectId
 
 interface SolutionRepository {
@@ -9,7 +10,7 @@ interface SolutionRepository {
     suspend fun createSolution(solution: Solution, files: List<UploadFileData>, userId: ObjectId): SolutionView
     suspend fun updateSolution(id: ObjectId, userId: ObjectId, solutionUpdates: SolutionUpdates): SolutionView
     suspend fun deleteSolutions(taskId: ObjectId)
-    suspend fun deleteSolution(id: ObjectId)
+    suspend fun deleteSolution(id: ObjectId, userId: ObjectId, parentTask: Task)
     suspend fun updateCommentAmount(solutionId: ObjectId, amount: Int): Int
     suspend fun vote(id: ObjectId, userId: ObjectId, voteType: VoteType): VoteUpdate
 }

--- a/src/main/kotlin/com/studyshare/solution/SolutionUpdates.kt
+++ b/src/main/kotlin/com/studyshare/solution/SolutionUpdates.kt
@@ -1,0 +1,11 @@
+package com.studyshare.solution
+
+import com.studyshare.forms.UploadFileData
+import org.bson.types.ObjectId
+
+class SolutionUpdates(
+    val title: String? = null,
+    val additionalNotes: String? = null,
+    val filesToDelete: List<ObjectId> = emptyList(),
+    val newFiles: List<UploadFileData> = emptyList()
+)

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -5,6 +5,7 @@ import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.studyshare.forms.UploadFileData
 import com.studyshare.attachment.AttachmentRepository
 import com.studyshare.comment.CommentRepository
+import com.studyshare.group.GroupRepository
 import com.studyshare.solution.Solution
 import com.studyshare.solution.SolutionRepository
 import com.studyshare.utils.ResourceModificationRestrictedException
@@ -91,10 +92,11 @@ class MongoTaskRepository(
         return createTaskView(updatedTask)
     }
 
-    override suspend fun deleteTask(id: ObjectId, userId: ObjectId): Task {
+    override suspend fun deleteTask(id: ObjectId, userId: ObjectId, groupRepository: GroupRepository): Task {
         val task = getTask(id)
+        val parentGroup = groupRepository.getGroup(task.groupId)
 
-        if (task.authorId != userId) {
+        if (task.authorId != userId && parentGroup.leaderId != userId) {
             throw ResourceModificationRestrictedException()
         }
 

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -9,6 +9,7 @@ import com.studyshare.attachment.AttachmentRepository
 import com.studyshare.comment.CommentRepository
 import com.studyshare.solution.Solution
 import com.studyshare.solution.SolutionRepository
+import com.studyshare.utils.ResourceNotFoundException
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.bson.types.ObjectId
@@ -51,9 +52,9 @@ class MongoTaskRepository(
         return taskCollection.find(filter).sort(sort).limit(resultCount).toList()
     }
 
-    override suspend fun getTask(id: ObjectId): TaskView? {
+    override suspend fun getTask(id: ObjectId): TaskView {
         val filter = Filters.eq("_id", id)
-        val task = taskCollection.find(filter).firstOrNull() ?: return null
+        val task = taskCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
         return TaskView(
             task = task,
             attachments = attachmentRepository.getAttachments(task.attachmentIds)
@@ -70,9 +71,9 @@ class MongoTaskRepository(
         taskCollection.findOneAndUpdate(filter, updates)
     }
 
-    override suspend fun deleteTask(id: ObjectId): Task? {
+    override suspend fun deleteTask(id: ObjectId): Task {
         val filter = Filters.eq("_id", id)
-        val task = taskCollection.findOneAndDelete(filter) ?: return null
+        val task = taskCollection.findOneAndDelete(filter) ?: throw ResourceNotFoundException()
 
         commentRepository.deleteComments(id)
         solutionRepository.deleteSolutions(taskId = task.id)

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -52,11 +52,10 @@ class MongoTaskRepository(
         )
 
         val sort = Sorts.descending("_id")
-
         return taskCollection.find(filter).sort(sort).limit(resultCount).toList()
     }
 
-    override suspend fun getTask(id: ObjectId): Task {
+    private suspend fun getTask(id: ObjectId): Task {
         val filter = Filters.eq("_id", id)
         return taskCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }
@@ -81,11 +80,9 @@ class MongoTaskRepository(
         val updatedAttachments = task.attachmentIds + newAttachments.map { it.attachment.id } - taskUpdates.filesToDelete.toSet()
 
         val updates = Updates.combine(
-            listOfNotNull(
-                Updates.set(Solution::title.name, taskUpdates.title),
-                Updates.set(Solution::additionalNotes.name, taskUpdates.additionalNotes),
-                Updates.set(Solution::attachmentIds.name, updatedAttachments)
-            )
+            Updates.set(Solution::title.name, taskUpdates.title),
+            Updates.set(Solution::additionalNotes.name, taskUpdates.additionalNotes),
+            Updates.set(Solution::attachmentIds.name, updatedAttachments)
         )
 
         val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -55,7 +55,7 @@ class MongoTaskRepository(
         return taskCollection.find(filter).sort(sort).limit(resultCount).toList()
     }
 
-    override suspend fun getTask(id: ObjectId): TaskView {
+    override suspend fun getTaskView(id: ObjectId): TaskView {
         val filter = Filters.eq("_id", id)
         val task = taskCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
         return createTaskView(task)

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -131,7 +131,7 @@ class MongoTaskRepository(
 
     override suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean {
         val filter = Filters.and(
-            Filters.eq("_id", groupId),
+            Filters.eq(Task::groupId.name, groupId),
             Filters.eq(Task::category.name, category)
         )
         return taskCollection.find(filter).firstOrNull() != null

--- a/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/MongoTaskRepository.kt
@@ -55,7 +55,7 @@ class MongoTaskRepository(
         return taskCollection.find(filter).sort(sort).limit(resultCount).toList()
     }
 
-    private suspend fun getTask(id: ObjectId): Task {
+    override suspend fun getTask(id: ObjectId): Task {
         val filter = Filters.eq("_id", id)
         return taskCollection.find(filter).firstOrNull() ?: throw ResourceNotFoundException()
     }

--- a/src/main/kotlin/com/studyshare/task/Task.kt
+++ b/src/main/kotlin/com/studyshare/task/Task.kt
@@ -1,6 +1,6 @@
 package com.studyshare.task
 
-import com.studyshare.utils.Post
+import com.studyshare.post.Post
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -7,7 +7,7 @@ interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
     suspend fun getTask(id: ObjectId): TaskView
-    suspend fun updateTask(id: ObjectId, newTask: Task)
+    suspend fun updateTask(id: ObjectId, taskUpdates: TaskUpdates): TaskView
     suspend fun deleteTask(id: ObjectId): Task
     suspend fun deleteTasks(groupId: ObjectId)
     suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -6,6 +6,7 @@ import org.bson.types.ObjectId
 interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
+    suspend fun getTask(id: ObjectId): Task
     suspend fun getTaskView(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, userId: ObjectId, taskUpdates: TaskUpdates): TaskView
     suspend fun deleteTask(id: ObjectId, userId: ObjectId): Task

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -1,6 +1,7 @@
 package com.studyshare.task
 
 import com.studyshare.forms.UploadFileData
+import com.studyshare.group.GroupRepository
 import org.bson.types.ObjectId
 
 interface TaskRepository {
@@ -9,7 +10,7 @@ interface TaskRepository {
     suspend fun getTask(id: ObjectId): Task
     suspend fun getTaskView(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, userId: ObjectId, taskUpdates: TaskUpdates): TaskView
-    suspend fun deleteTask(id: ObjectId, userId: ObjectId): Task
+    suspend fun deleteTask(id: ObjectId, userId: ObjectId, groupRepository: GroupRepository): Task
     suspend fun deleteTasks(groupId: ObjectId)
     suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean
     suspend fun updateCommentAmount(taskId: ObjectId, amount: Int): Int

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -6,9 +6,9 @@ import org.bson.types.ObjectId
 interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
-    suspend fun getTask(id: ObjectId): TaskView?
+    suspend fun getTask(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, newTask: Task)
-    suspend fun deleteTask(id: ObjectId): Task?
+    suspend fun deleteTask(id: ObjectId): Task
     suspend fun deleteTasks(groupId: ObjectId)
     suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean
 

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -6,7 +6,7 @@ import org.bson.types.ObjectId
 interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
-    suspend fun getTask(id: ObjectId): TaskView
+    suspend fun getTaskView(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, taskUpdates: TaskUpdates): TaskView
     suspend fun deleteTask(id: ObjectId): Task
     suspend fun deleteTasks(groupId: ObjectId)

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -6,7 +6,6 @@ import org.bson.types.ObjectId
 interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
-    suspend fun getTask(id: ObjectId): Task
     suspend fun getTaskView(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, userId: ObjectId, taskUpdates: TaskUpdates): TaskView
     suspend fun deleteTask(id: ObjectId, userId: ObjectId): Task

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -9,7 +9,7 @@ interface TaskRepository {
     suspend fun getTask(id: ObjectId): Task
     suspend fun getTaskView(id: ObjectId): TaskView
     suspend fun updateTask(id: ObjectId, userId: ObjectId, taskUpdates: TaskUpdates): TaskView
-    suspend fun deleteTask(id: ObjectId): Task
+    suspend fun deleteTask(id: ObjectId, userId: ObjectId): Task
     suspend fun deleteTasks(groupId: ObjectId)
     suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean
     suspend fun updateCommentAmount(taskId: ObjectId, amount: Int): Int

--- a/src/main/kotlin/com/studyshare/task/TaskRepository.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskRepository.kt
@@ -6,11 +6,11 @@ import org.bson.types.ObjectId
 interface TaskRepository {
     suspend fun getTasks(groupId: ObjectId, category: String?, resultCount: Int, lastId: ObjectId?): List<Task>
     suspend fun createTask(task: Task, files: List<UploadFileData>): TaskView
+    suspend fun getTask(id: ObjectId): Task
     suspend fun getTaskView(id: ObjectId): TaskView
-    suspend fun updateTask(id: ObjectId, taskUpdates: TaskUpdates): TaskView
+    suspend fun updateTask(id: ObjectId, userId: ObjectId, taskUpdates: TaskUpdates): TaskView
     suspend fun deleteTask(id: ObjectId): Task
     suspend fun deleteTasks(groupId: ObjectId)
     suspend fun doesCategoryExist(groupId: ObjectId, category: String): Boolean
-
     suspend fun updateCommentAmount(taskId: ObjectId, amount: Int): Int
 }

--- a/src/main/kotlin/com/studyshare/task/TaskUpdates.kt
+++ b/src/main/kotlin/com/studyshare/task/TaskUpdates.kt
@@ -1,0 +1,11 @@
+package com.studyshare.task
+
+import com.studyshare.forms.UploadFileData
+import org.bson.types.ObjectId
+
+class TaskUpdates(
+    val title: String? = null,
+    val additionalNotes: String? = null,
+    val filesToDelete: List<ObjectId> = emptyList(),
+    val newFiles: List<UploadFileData> = emptyList()
+)

--- a/src/main/kotlin/com/studyshare/templates/Comment.kt
+++ b/src/main/kotlin/com/studyshare/templates/Comment.kt
@@ -1,7 +1,7 @@
 package com.studyshare.templates
 
 import com.studyshare.comment.Comment
-import com.studyshare.utils.Post
+import com.studyshare.post.Post
 import com.studyshare.utils.className
 import kotlinx.html.FlowContent
 import kotlinx.html.*

--- a/src/main/kotlin/com/studyshare/templates/FormModal.kt
+++ b/src/main/kotlin/com/studyshare/templates/FormModal.kt
@@ -1,5 +1,6 @@
 package com.studyshare.templates
 
+import com.studyshare.attachment.AttachmentView
 import com.studyshare.forms.Form
 import com.studyshare.forms.HtmxRequestType
 import kotlinx.html.FlowContent
@@ -14,7 +15,8 @@ fun FlowContent.formModalDialog(
     requestType: HtmxRequestType = HtmxRequestType.POST,
     inputDataLists: Map<String, List<String>>? = null,
     extraAttributes: Map<String, String>? = null,
-    inputValues: Map<String, String>? = null
+    inputValues: Map<String, String>? = null,
+    filesToBeDeleted: Map<String, List<AttachmentView>>? = null
 ) {
 
     val formScript = """
@@ -37,6 +39,8 @@ fun FlowContent.formModalDialog(
         submitAttributes = mapOf(),
         modalWrapper = modalWrapper
     ) {
-        form.renderInputFields(this, inputDataLists = inputDataLists, inputValues = inputValues)
+        form.renderInputFields(
+            this, inputDataLists = inputDataLists, inputValues = inputValues, filesToBeDeleted = filesToBeDeleted
+        )
     }
 }

--- a/src/main/kotlin/com/studyshare/templates/Group.kt
+++ b/src/main/kotlin/com/studyshare/templates/Group.kt
@@ -33,10 +33,10 @@ fun FlowContent.groupHeader(groupView: GroupView, userSession: UserSession) {
         attributes["id"] = "group-header-${groupView.group.id}"
         div(classes = "group-info") {
             groupView.thumbnail?.let {
-                div {
-                    classes = setOf("group-thumbnail")
-                    img(src = it.thumbnailUrl, alt = "${groupView.group.title}'s thumbnail")
-                }
+                img(
+                    classes = "group-thumbnail",
+                    src = it.thumbnailUrl,
+                    alt = "${groupView.group.title}'s thumbnail")
             }
             div {
                 classes = setOf("group-info-text")

--- a/src/main/kotlin/com/studyshare/templates/Group.kt
+++ b/src/main/kotlin/com/studyshare/templates/Group.kt
@@ -28,11 +28,9 @@ fun FlowContent.groupThumbnailTemplate(groupView: GroupView) {
     }
 }
 
-fun FlowContent.groupViewTemplate(groupView: GroupView, userSession: UserSession) {
-
-    val groupId = groupView.group.id
-
+fun FlowContent.groupHeader(groupView: GroupView, userSession: UserSession) {
     div(classes = "group-header") {
+        attributes["id"] = "group-header-${groupView.group.id}"
         div(classes = "group-info") {
             groupView.thumbnail?.let {
                 div {
@@ -50,14 +48,24 @@ fun FlowContent.groupViewTemplate(groupView: GroupView, userSession: UserSession
                 }
             }
         }
-        div(classes = "group-options") {
-            if (groupView.group.leaderId == ObjectId(userSession.id)) {
-                deletionButton(
-                    getUrl = "/$groupId/group-deletion-confirmation?groupTitle=${groupView.group.title}"
-                )
-            }
+
+        if (groupView.group.leaderId == ObjectId(userSession.id)) {
+            editButton(
+                getUrl = "/${groupView.group.id}/edition-modal"
+            )
+            deletionButton(
+                getUrl = "/${groupView.group.id}/group-deletion-confirmation?groupTitle=${groupView.group.title}"
+            )
         }
     }
+}
+
+fun FlowContent.groupViewTemplate(groupView: GroupView, userSession: UserSession) {
+
+    val groupId = groupView.group.id
+
+    groupHeader(groupView, userSession)
+
     section(classes = "wide-button-container") {
         modalOpenButton(
             buttonText = "Create a task",
@@ -89,23 +97,12 @@ fun FlowContent.userListItem(user: User, groupId: ObjectId, showKickButton: Bool
             +user.name
         }
         if (showKickButton) {
-//            button(classes = "btn secondary outline") {
-//                attributes["_"] = "on click add .invisible to me toggle @disabled on me"
-//                attributes["hx-get"] = "/$groupId/user-deletion-confirmation?userId=${user.id}&name=${user.name}"
-//                attributes["hx-target"] = "#$userItemId"
-//                attributes["hx-swap"] = "afterend"
-//
-//                span(classes = "material-symbols-rounded") {
-//                    +"delete"
-//                }
-//            }
             iconButton(
                 ButtonType.DELETE,
                 "/$groupId/user-deletion-confirmation?userId=${user.id}&name=${user.name}",
                 additionalScript = "on htmx:afterRequest add .invisible to me toggle @disabled on me",
                 buttonAttributes = mapOf("hx-target" to "#$userItemId", "hx-swap" to "afterend")
             )
-
         }
     }
     hr {

--- a/src/main/kotlin/com/studyshare/templates/Post.kt
+++ b/src/main/kotlin/com/studyshare/templates/Post.kt
@@ -4,11 +4,20 @@ import com.studyshare.solution.Solution
 import com.studyshare.task.Task
 import com.studyshare.post.Post
 import kotlinx.html.*
+import org.bson.types.ObjectId
 
 enum class AccessLevel {
     NONE,
     DELETE,
     EDIT
+}
+
+fun getAccessLevel(userId: ObjectId, authorId: ObjectId, parentAuthorId: ObjectId? = null): AccessLevel {
+    return when (userId) {
+        authorId -> AccessLevel.EDIT
+        parentAuthorId -> AccessLevel.DELETE
+        else -> AccessLevel.NONE
+    }
 }
 
 fun FlowContent.postDeletionButton(post: Post) {
@@ -33,6 +42,9 @@ fun FlowContent.postActions(post: Post, accessLevel: AccessLevel) {
     when (accessLevel) {
         AccessLevel.NONE -> return
         AccessLevel.DELETE -> postDeletionButton(post)
-        AccessLevel.EDIT -> {postEditingButton(post); postDeletionButton(post)}
+        AccessLevel.EDIT -> {
+            postEditingButton(post)
+            postDeletionButton(post)
+        }
     }
 }

--- a/src/main/kotlin/com/studyshare/templates/Post.kt
+++ b/src/main/kotlin/com/studyshare/templates/Post.kt
@@ -2,7 +2,7 @@ package com.studyshare.templates
 
 import com.studyshare.solution.Solution
 import com.studyshare.task.Task
-import com.studyshare.utils.Post
+import com.studyshare.post.Post
 import kotlinx.html.*
 
 enum class AccessLevel {

--- a/src/main/kotlin/com/studyshare/templates/Task.kt
+++ b/src/main/kotlin/com/studyshare/templates/Task.kt
@@ -25,7 +25,7 @@ fun FlowContent.taskTemplate(taskView: TaskView, accessLevel: AccessLevel) {
         }
         if (taskView.task.additionalNotes != null) {
             p {
-                    +"${taskView.task.additionalNotes}"
+                +"${taskView.task.additionalNotes}"
             }
         }
 

--- a/src/main/kotlin/com/studyshare/utils/ParameterValidators.kt
+++ b/src/main/kotlin/com/studyshare/utils/ParameterValidators.kt
@@ -64,3 +64,14 @@ suspend fun validateGroupBelonging(call: RoutingCall, groupRepository: GroupRepo
     }
     return true
 }
+
+fun parseObjectIdList(list: List<String>): List<ObjectId>? {
+    val parsedList = list.map {
+        if (ObjectId.isValid(it)) {
+            ObjectId(it)
+        } else {
+            return null
+        }
+    }
+    return parsedList
+}

--- a/src/main/kotlin/com/studyshare/utils/Post.kt
+++ b/src/main/kotlin/com/studyshare/utils/Post.kt
@@ -3,12 +3,6 @@ package com.studyshare.utils
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 
-class PostModificationRestrictedException(): Exception(
-    "Post Modification Restricted - Ownership Required"
-)
-
-class PostNotFoundException(): Exception("Post not found")
-
 abstract class Post {
     @get:BsonId
     abstract val id: ObjectId

--- a/src/main/kotlin/com/studyshare/utils/Post.kt
+++ b/src/main/kotlin/com/studyshare/utils/Post.kt
@@ -3,7 +3,13 @@ package com.studyshare.utils
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 
-abstract class Post{
+class PostModificationRestrictedException(): Exception(
+    "Post Modification Restricted - Ownership Required"
+)
+
+class PostNotFoundException(): Exception("Post not found")
+
+abstract class Post {
     @get:BsonId
     abstract val id: ObjectId
 

--- a/src/main/kotlin/com/studyshare/utils/ResourceExceptions.kt
+++ b/src/main/kotlin/com/studyshare/utils/ResourceExceptions.kt
@@ -1,0 +1,7 @@
+package com.studyshare.utils
+
+class ResourceNotFoundException(): Exception("Resource not found")
+
+class ResourceModificationRestrictedException(): Exception(
+    "Resource Modification Restricted - Ownership Required"
+)

--- a/src/main/kotlin/com/studyshare/utils/methods.kt
+++ b/src/main/kotlin/com/studyshare/utils/methods.kt
@@ -1,8 +1,5 @@
 package com.studyshare.utils
 
-import com.studyshare.templates.AccessLevel
-import org.bson.types.ObjectId
-
 fun className(any: Any): String {
     val str = any.javaClass.toString().lowercase()
     val lastDotIndex = str.lastIndexOf('.')
@@ -10,13 +7,5 @@ fun className(any: Any): String {
         str.substring(lastDotIndex + 1)
     } else {
         str
-    }
-}
-
-fun getAccessLevel(userId: ObjectId, authorId: ObjectId, parentAuthorId: ObjectId? = null): AccessLevel {
-    return when (userId) {
-        authorId -> AccessLevel.EDIT
-        parentAuthorId -> AccessLevel.DELETE
-        else -> AccessLevel.NONE
     }
 }

--- a/static/helperFunctions.js
+++ b/static/helperFunctions.js
@@ -3,3 +3,13 @@ function convertUTCDateToLocalDate(epoch) {
     date.setUTCSeconds(epoch);
     return date.toLocaleString();
 }
+
+function appendValue(input, newValue) {
+    input.value += newValue;
+    input.value += ";";
+}
+
+function incContent(tag) {
+    const prevValue = parseInt(tag.textContent)
+    tag.textContent = prevValue + 1
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -479,6 +479,7 @@ details summary {
 .user-deletion-confirmation > small {
     display: flex;
     align-items: center;
+    margin: 0 1rem;
 }
 
 .user-deletion-confirmation > button {

--- a/static/styles.css
+++ b/static/styles.css
@@ -391,6 +391,7 @@ hr:last-child {
     display: flex;
     flex-direction: row;
     margin-bottom: 1rem;
+    flex-grow: 1
 }
 
 .group-info > .group-thumbnail {
@@ -515,7 +516,7 @@ article > .user-list-item:first-of-type {
 
 .group-header {
     display: flex;
-    justify-content: space-between;
+    align-items: flex-start;
 }
 
 .icon-btn::before {

--- a/static/styles.css
+++ b/static/styles.css
@@ -399,6 +399,7 @@ hr:last-child {
     object-fit: cover;
     width: 20%;
     margin-right: 1rem;
+    border-radius: 0.25rem;
 }
 
 
@@ -406,10 +407,6 @@ hr:last-child {
     .group-info > .group-thumbnail {
         width: 30%;
     }
-}
-
-.group-info > .group-thumbnail > img {
-    border-radius: 0.25rem;
 }
 
 .modal-content {

--- a/static/styles.css
+++ b/static/styles.css
@@ -521,3 +521,43 @@ article > .user-list-item:first-of-type {
 .icon-btn::before {
     margin-inline-end: 0 !important;
 }
+
+.img-to-be-deleted {
+    position: relative;
+}
+
+.non-img-to-be-deleted {
+    display: flex;
+    justify-content: start;
+}
+
+.non-img-to-be-deleted > span {
+    display: flex;
+    align-items: center;
+    margin-right: 0.5em;
+}
+
+.file-deletion-btn {
+    padding: 0;
+    background-color: var(--pico-del-color) !important;
+    border: 1px solid var(--pico-del-color);
+}
+
+.img-to-be-deleted .file-deletion-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.deleted-count-text {
+    text-align: center;
+}
+
+.attachments {
+    display: flex;
+    flex-direction: column;
+}
+
+.attachments > a {
+    margin: 0.3em 0;
+}


### PR DESCRIPTION
Changes made:
- create FileDeletionInput to allow the user to delete already uploaded attachments,
- create ResourceNotFound and ResourceModificationRestricted custom Exceptions,
- refactor existing repository methods to use the new Exceptions instead of returning null on error,
- improve 4xx error messages,
- add ability to edit attachments in the Tasks and Solutions,
- add ability to edit Groups,
- move edit/delete permission check logic from route handlers into the repositories,
- allow Group Leaders to delete any Task in their Groups
- made cosmetic visual improvements to the group thumbnail and user deletion confirmation.